### PR TITLE
v5.2.3

### DIFF
--- a/DMMGamePlayerFastLauncher/static/config.py
+++ b/DMMGamePlayerFastLauncher/static/config.py
@@ -37,5 +37,5 @@ class UrlConfig(Dump):
 
 
 class SchtasksConfig(Dump):
-    FILE = "schtasks_v2_{0}_{1}"
+    FILE = "schtasks_v1_{0}_{1}"
     NAME = "\\Microsoft\\Windows\\DMMGamePlayerFastLauncher\\{0}"

--- a/DMMGamePlayerFastLauncher/static/config.py
+++ b/DMMGamePlayerFastLauncher/static/config.py
@@ -37,5 +37,5 @@ class UrlConfig(Dump):
 
 
 class SchtasksConfig(Dump):
-    FILE = "schtasks_v1_{0}_{1}"
+    FILE = "schtasks_v2_{0}_{1}"
     NAME = "\\Microsoft\\Windows\\DMMGamePlayerFastLauncher\\{0}"

--- a/DMMGamePlayerFastLauncher/static/env.py
+++ b/DMMGamePlayerFastLauncher/static/env.py
@@ -8,7 +8,7 @@ from windows_pathlib import WindowsPathlib
 
 
 class Env(Dump):
-    VERSION = "v5.2.2"
+    VERSION = "v5.2.3"
     RELEASE_VERSION = requests.get(UrlConfig.RELEASE_API).json().get("tag_name", VERSION)
 
     DEVELOP: bool = os.environ.get("ENV") == "DEVELOP"

--- a/assets/template/schtasks.xml
+++ b/assets/template/schtasks.xml
@@ -3,7 +3,7 @@
   <RegistrationInfo>
     <Date>2023-01-01T00:00:00</Date>
     <Author>fa0311</Author>
-    <Description>uac_bypass_v1</Description>
+    <Description>uac_bypass_v2</Description>
     <URI>\Microsoft\Windows\DMMGamePlayerFastLauncher\{{UID}}</URI>
   </RegistrationInfo>
   <Triggers />

--- a/assets/template/schtasks.xml
+++ b/assets/template/schtasks.xml
@@ -3,7 +3,7 @@
   <RegistrationInfo>
     <Date>2023-01-01T00:00:00</Date>
     <Author>fa0311</Author>
-    <Description>uac_bypass_v2</Description>
+    <Description>uac_bypass_v1</Description>
     <URI>\Microsoft\Windows\DMMGamePlayerFastLauncher\{{UID}}</URI>
   </RegistrationInfo>
   <Triggers />

--- a/setup.iss
+++ b/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "DMMGamePlayerFastLauncher"
-#define MyAppVersion "5.2.2"
+#define MyAppVersion "5.2.3"
 #define MyAppPublisher "yuki"
 #define MyAppURL "https://github.com/fa0311/DMMGamePlayerFastLauncher"
 #define MyAppExeName "DMMGamePlayerFastLauncher.exe"

--- a/windows/tools/refresh.ps1
+++ b/windows/tools/refresh.ps1
@@ -5,5 +5,5 @@ if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 
 Get-ScheduledTask | Where-Object TaskPath -eq "\Microsoft\Windows\DMMGamePlayerFastLauncher\" | Unregister-ScheduledTask -Confirm:$false
 $schtasks = Join-Path -Path (Split-Path -Path ($PSScriptRoot) -Parent) -ChildPath "data\schtasks"
-Get-ChildItem -Path $schtasks | ForEach-Object { schtasks.exe /create /xml $_.FullName /tn $_.Name }
+Get-ChildItem -Path $schtasks | ForEach-Object { schtasks.exe /create /xml $_.FullName /tn "\Microsoft\Windows\DMMGamePlayerFastLauncher\$($_.Name -replace '\.xml$')" }
 Read-Host -Prompt "Press Enter to exit"

--- a/windows/tools/refresh.ps1
+++ b/windows/tools/refresh.ps1
@@ -1,2 +1,9 @@
-if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("Administrators")) { Start-Process powershell.exe "-File `"$PSCommandPath`" -NoNewWindow -Wait" -Verb RunAs; exit }
-Get-ScheduledTask | where TaskPath -eq "\Microsoft\Windows\DMMGamePlayerFastLauncher\" | Unregister-ScheduledTask -Confirm:$false
+if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("Administrators")) {
+    Start-Process powershell.exe "-File `"$PSCommandPath`" -NoNewWindow -Wait" -WorkingDirectory $PSScriptRoot -Verb RunAs;
+    exit;
+}
+
+Get-ScheduledTask | Where-Object TaskPath -eq "\Microsoft\Windows\DMMGamePlayerFastLauncher\" | Unregister-ScheduledTask -Confirm:$false
+$schtasks = Join-Path -Path (Split-Path -Path ($PSScriptRoot) -Parent) -ChildPath "data\schtasks"
+Get-ChildItem -Path $schtasks | ForEach-Object { schtasks.exe /create /xml $_.FullName /tn $_.Name }
+Read-Host -Prompt "Press Enter to exit"


### PR DESCRIPTION
`refresh.ps1` を作った、実行すると `data\schtasks` のスケジュールを再登録する
https://github.com/fa0311/DMMGamePlayerFastLauncher/pull/110 でスケジュールを変えたときに `uac_bypass_v1` を `uac_bypass_v2` にするかどうかを検討