### PR TITLE
add PySocks to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ pyinstaller @ git+https://github.com/fa0311/pyinstaller@4bbed269a4e759f920c59aec
 pyinstaller-hooks-contrib==2022.14
 pypresence==4.3.0
 pyreadline3==3.4.1
+PySocks==1.7.1
 python-dateutil==2.8.2
 pytz==2022.7.1
 pywin32==305


### PR DESCRIPTION
Attempting to launch with "DMM HTTPS Proxy" set to a URL beginning with `socks5://` returns the following error:

```
Traceback (most recent call last):
  File "launch.py", line 46, in thread
  File "launch.py", line 60, in launch
  File "lib\DGPSessionWrap.py", line 11, in read_cookies
  File "lib\DGPSessionV2.py", line 298, in read_cookies
  File "lib\DGPSessionV2.py", line 222, in login
  File "lib\DGPSessionV2.py", line 177, in get
  File "requests\sessions.py", line 600, in get
  File "requests\sessions.py", line 587, in request
  File "requests\sessions.py", line 701, in send
  File "requests\adapters.py", line 456, in send
  File "requests\adapters.py", line 352, in get_connection
  File "requests\adapters.py", line 217, in proxy_manager_for
  File "requests\adapters.py", line 62, in SOCKSProxyManager
requests.exceptions.InvalidSchema: Missing dependencies for SOCKS support.
```

Add PySocks as described by https://requests.readthedocs.io/en/latest/user/advanced/#socks (`pip install requests[socks]`)