### PR TITLE
fix: PROXIES not beeing used

### DIFF
--- a/DMMGamePlayerFastLauncher/lib/DGPSessionV2.py
+++ b/DMMGamePlayerFastLauncher/lib/DGPSessionV2.py
@@ -97,6 +97,7 @@ class DgpSessionV2:
         self.session = requests.Session()
         self.session.cookies = requests.cookies.RequestsCookieJar()
         self.session.cookies.set("age_check_done", "0", domain=".dmm.com", path="/")
+        self.session.proxies = self.PROXY
 
     def write_safe(self, data: bytes):
         file = self.DGP5_DATA_PATH.joinpath("authAccessTokenData.enc")
@@ -153,27 +154,27 @@ class DgpSessionV2:
 
     def get(self, url: str, params=None, **kwargs) -> requests.Response:
         self.LOGGER.info("params %s", params)
-        res = self.session.get(url, headers=self.HEADERS, params=params, proxies=self.PROXY, **kwargs)
+        res = self.session.get(url, headers=self.HEADERS, params=params, **kwargs)
         return self.logger(res)
 
     def post(self, url: str, json=None, **kwargs) -> requests.Response:
         self.LOGGER.info("json %s", json)
-        res = self.session.post(url, headers=self.HEADERS, json=json, proxies=self.PROXY, **kwargs)
+        res = self.session.post(url, headers=self.HEADERS, json=json, **kwargs)
         return self.logger(res)
 
     def get_dgp(self, url: str, params=None, **kwargs) -> requests.Response:
         self.LOGGER.info("params %s", params)
-        res = self.session.get(url, headers=self.get_headers(), params=params, proxies=self.PROXY, **kwargs)
+        res = self.session.get(url, headers=self.get_headers(), params=params, **kwargs)
         return self.logger(res)
 
     def post_dgp(self, url: str, json=None, **kwargs) -> requests.Response:
         self.LOGGER.info("json %s", json)
-        res = self.session.post(url, headers=self.get_headers(), json=json, proxies=self.PROXY, **kwargs)
+        res = self.session.post(url, headers=self.get_headers(), json=json, **kwargs)
         return self.logger(res)
 
     def post_device_dgp(self, url: str, json=None, **kwargs) -> requests.Response:
         json = (json or {}) | self.DGP5_DEVICE_PARAMS
-        return self.post_dgp(url, json=json, proxies=self.PROXY, **kwargs)
+        return self.post_dgp(url, json=json, **kwargs)
 
     def logger(self, res: requests.Response) -> requests.Response:
         if res.headers.get("Content-Type") == "application/json":

--- a/DMMGamePlayerFastLauncher/lib/DGPSessionV2.py
+++ b/DMMGamePlayerFastLauncher/lib/DGPSessionV2.py
@@ -153,27 +153,27 @@ class DgpSessionV2:
 
     def get(self, url: str, params=None, **kwargs) -> requests.Response:
         self.LOGGER.info("params %s", params)
-        res = self.session.get(url, headers=self.HEADERS, params=params, **kwargs)
+        res = self.session.get(url, headers=self.HEADERS, params=params, proxies=self.PROXY, **kwargs)
         return self.logger(res)
 
     def post(self, url: str, json=None, **kwargs) -> requests.Response:
         self.LOGGER.info("json %s", json)
-        res = self.session.post(url, headers=self.HEADERS, json=json, **kwargs)
+        res = self.session.post(url, headers=self.HEADERS, json=json, proxies=self.PROXY, **kwargs)
         return self.logger(res)
 
     def get_dgp(self, url: str, params=None, **kwargs) -> requests.Response:
         self.LOGGER.info("params %s", params)
-        res = self.session.get(url, headers=self.get_headers(), params=params, **kwargs)
+        res = self.session.get(url, headers=self.get_headers(), params=params, proxies=self.PROXY, **kwargs)
         return self.logger(res)
 
     def post_dgp(self, url: str, json=None, **kwargs) -> requests.Response:
         self.LOGGER.info("json %s", json)
-        res = self.session.post(url, headers=self.get_headers(), json=json, **kwargs)
+        res = self.session.post(url, headers=self.get_headers(), json=json, proxies=self.PROXY, **kwargs)
         return self.logger(res)
 
     def post_device_dgp(self, url: str, json=None, **kwargs) -> requests.Response:
         json = (json or {}) | self.DGP5_DEVICE_PARAMS
-        return self.post_dgp(url, json=json, **kwargs)
+        return self.post_dgp(url, json=json, proxies=self.PROXY, **kwargs)
 
     def logger(self, res: requests.Response) -> requests.Response:
         if res.headers.get("Content-Type") == "application/json":


### PR DESCRIPTION
Hey,

it seemed like the http & https proxies beeing set in [DMMGamePlayerFastLauncher.py](https://github.com/fa0311/DMMGamePlayerFastLauncher/blob/33825c38fa9160945d8f9f171f5af930d511e34a/DMMGamePlayerFastLauncher/DMMGamePlayerFastLauncher.py#L73) weren't used so the launch.py threw an area not allowed. This PR fixes this by setting the proxies for the request module to self.PROXIES