### PR TITLE
Fix shortcut source variable

### DIFF
--- a/DMMGamePlayerFastLauncher/lib/process_manager.py
+++ b/DMMGamePlayerFastLauncher/lib/process_manager.py
@@ -138,7 +138,7 @@ class Schtasks:
 
 
 class Shortcut:
-    def create(self, sorce: Path, target: Optional[Path] = None, args: Optional[list[str]] = None, icon: Optional[Path] = None):
+    def create(self, source: Path, target: Optional[Path] = None, args: Optional[list[str]] = None, icon: Optional[Path] = None):
         with open(AssetsPathConfig.SHORTCUT, "r", encoding="utf-8") as f:
             template = f.read()
         if icon is None:
@@ -153,7 +153,7 @@ class Shortcut:
             else:
                 target = Path(sys.argv[0])
 
-        template = template.replace(r"{{SORCE}}", str(sorce.absolute()))
+        template = template.replace(r"{{SOURCE}}", str(source.absolute()))
         template = template.replace(r"{{TARGET}}", str(target))
         template = template.replace(r"{{WORKING_DIRECTORY}}", os.getcwd())
         template = template.replace(r"{{ICON_LOCATION}}", str(icon.absolute()))

--- a/DMMGamePlayerFastLauncher/tab/shortcut.py
+++ b/DMMGamePlayerFastLauncher/tab/shortcut.py
@@ -136,9 +136,9 @@ class ShortcutBase(CTkScrollableFrame):
             except Exception:
                 name, icon = self.filename.get(), None
                 self.toast.error(i18n.t("app.shortcut.game_info_error"))
-            sorce = Env.DESKTOP.joinpath(name).with_suffix(".lnk")
+            source = Env.DESKTOP.joinpath(name).with_suffix(".lnk")
             args = ["/run", "/tn", task.name]
-            Shortcut().create(sorce=sorce, target=Env.SCHTASKS, args=args, icon=icon)
+            Shortcut().create(source=source, target=Env.SCHTASKS, args=args, icon=icon)
             self.toast.info(i18n.t("app.shortcut.save_success"))
 
         self.save_handler(fn)
@@ -152,9 +152,9 @@ class ShortcutBase(CTkScrollableFrame):
                 except Exception:
                     name, icon = self.filename.get(), None
                     self.toast.error(i18n.t("app.shortcut.game_info_error"))
-                sorce = Env.DESKTOP.joinpath(name).with_suffix(".lnk")
+                source = Env.DESKTOP.joinpath(name).with_suffix(".lnk")
                 args = [self.filename.get()]
-                Shortcut().create(sorce=sorce, args=args, icon=icon)
+                Shortcut().create(source=source, args=args, icon=icon)
                 self.toast.info(i18n.t("app.shortcut.save_success"))
             except Exception:
                 DataPathConfig.SHORTCUT.joinpath(self.filename.get()).with_suffix(".json").unlink()
@@ -176,9 +176,9 @@ class ShortcutBase(CTkScrollableFrame):
             except Exception:
                 DataPathConfig.SHORTCUT.joinpath(self.filename.get()).with_suffix(".json").unlink()
                 raise
-            sorce = Env.DESKTOP.joinpath(name).with_suffix(".lnk")
+            source = Env.DESKTOP.joinpath(name).with_suffix(".lnk")
             args = [self.filename.get()]
-            Shortcut().create(sorce=sorce, args=args, icon=icon)
+            Shortcut().create(source=source, args=args, icon=icon)
             self.toast.info(i18n.t("app.shortcut.save_success"))
 
         self.save_handler(fn)
@@ -350,10 +350,10 @@ class LauncherShortcutBase(CTkScrollableFrame):
         self.save()
         try:
             name = self.filename.get()
-            sorce = Env.DESKTOP.joinpath(name).with_suffix(".lnk")
+            source = Env.DESKTOP.joinpath(name).with_suffix(".lnk")
             args = [name, "--type", "launcher"]
             icon = AppConfig.DATA.dmm_game_player_program_folder.get_path().joinpath("DMMGamePlayer.exe")
-            Shortcut().create(sorce=sorce, args=args, icon=icon)
+            Shortcut().create(source=source, args=args, icon=icon)
             self.toast.info(i18n.t("app.shortcut.save_success"))
         except Exception:
             DataPathConfig.ACCOUNT_SHORTCUT.joinpath(self.filename.get()).with_suffix(".json").unlink()

--- a/assets/template/shortcut.ps1
+++ b/assets/template/shortcut.ps1
@@ -1,5 +1,5 @@
 $WshShell = New-Object -ComObject WScript.Shell;
-$ShortCut = $WshShell.CreateShortcut("{{SORCE}}");
+$ShortCut = $WshShell.CreateShortcut("{{SOURCE}}");
 $ShortCut.TargetPath = "{{TARGET}}";
 $ShortCut.WorkingDirectory = "{{WORKING_DIRECTORY}}";
 $ShortCut.IconLocation = "{{ICON_LOCATION}}";


### PR DESCRIPTION
## Summary
- rename `sorce` parameter to `source`
- update shortcut template variable name
- adapt calls in the UI for new argument

## Testing
- `python3 -m unittest discover -v test` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_b_682c94652f348331b435a9d465af8e3f