### PR TITLE
perf(process_manager): batch process enumeration, cache SID lookup

### DIFF
--- a/DMMGamePlayerFastLauncher/lib/process_manager.py
+++ b/DMMGamePlayerFastLauncher/lib/process_manager.py
@@ -1,4 +1,5 @@
 import ctypes
+import functools
 import logging
 import os
 import subprocess
@@ -50,14 +51,11 @@ class ProcessIdManager:
     process: list[tuple[int, Optional[str]]]
 
     def __init__(self, _process: Optional[list[tuple[int, Optional[str]]]] = None) -> None:
-        def wrapper(x: psutil.Process) -> Optional[str]:
-            try:
-                return x.exe()
-            except Exception:
-                return None
-
         if _process is None:
-            self.process = [(x.pid, wrapper(x)) for x in psutil.process_iter()]
+            # Fetch pid + exe in a single process_iter pass. attrs= populates `.info`
+            # and yields None for exe when access is denied (same result as the old
+            # per-process .exe() try/except), but avoids one syscall per process.
+            self.process = [(p.info["pid"], p.info["exe"]) for p in psutil.process_iter(attrs=["pid", "exe"])]
         else:
             self.process = _process
 
@@ -88,7 +86,10 @@ class ProcessIdManager:
         return process[0]
 
 
+@functools.lru_cache(maxsize=1)
 def get_sid() -> str:
+    # The current user's SID is constant for the process lifetime; cache the
+    # win32 lookup so repeated Schtasks operations don't re-query it.
     username = os.getlogin()
     sid, domain, type = win32security.LookupAccountName("", username)
     sidstr = win32security.ConvertSidToStringSid(sid)


### PR DESCRIPTION
### Summary

Two small, behaviour-preserving performance tweaks in `lib/process_manager.py`.

### 1. Batch process enumeration

`ProcessIdManager.__init__` called `x.exe()` for every process from `process_iter()` - one syscall per process. Since `new_process()` builds a fresh snapshot before and after each launch to diff them, this runs on the full process table repeatedly.

`process_iter(attrs=["pid", "exe"])` fetches both fields in a single pass and stores `None` for `exe` when access is denied - the same result the old `try/except` wrapper produced - without the per-process call. This is the pattern the [psutil docs](https://psutil.readthedocs.io/en/latest/#psutil.process_iter) recommend.

### 2. Cache the SID lookup

`get_sid()` performs a win32 `LookupAccountName` + `ConvertSidToStringSid` on every call, but the current user's SID is constant for the process lifetime. `functools.lru_cache(maxsize=1)` makes repeated `Schtasks` operations reuse the first result.

### Notes

No behavioural change; output is identical. Net `+8 / -7`.